### PR TITLE
Load WordPress correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "alleyinteractive/composer-wordpress-autoloader": ">=0.4",
+        "alleyinteractive/composer-wordpress-autoloader": "^0.6.0",
         "mantle-framework/testkit": "^0.5",
         "pestphp/pest-plugin": "^1.0",
         "pestphp/pest": "^1.0"

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -2,5 +2,10 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../vendor/wordpress-autoload.php';
+if ( file_exists( dirname( __DIR__, 3 ) . '/wordpress-autoload.php' ) ) {
+    require_once dirname( __DIR__, 3 ) . '/wordpress-autoload.php';
+} else {
+    require_once __DIR__ . '/../vendor/wordpress-autoload.php';
+}
+
 require_once __DIR__ . '/Http.php';

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -2,10 +2,4 @@
 
 declare(strict_types=1);
 
-if (file_exists(dirname(__DIR__, 3) . '/wordpress-autoload.php')) {
-    require_once dirname(__DIR__, 3) . '/wordpress-autoload.php';
-} else {
-    require_once __DIR__ . '/../vendor/wordpress-autoload.php';
-}
-
 require_once __DIR__ . '/Http.php';

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-if ( file_exists( dirname( __DIR__, 3 ) . '/wordpress-autoload.php' ) ) {
-    require_once dirname( __DIR__, 3 ) . '/wordpress-autoload.php';
+if (file_exists(dirname(__DIR__, 3) . '/wordpress-autoload.php')) {
+    require_once dirname(__DIR__, 3) . '/wordpress-autoload.php';
 } else {
     require_once __DIR__ . '/../vendor/wordpress-autoload.php';
 }


### PR DESCRIPTION
When this plugin is installed in a project, the path to the `wordpress-autoload.php` file is different from the one in this repo.